### PR TITLE
Update matches to append

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function matchesToFile(path, resourcePath, matches) {
 	try {
 		searchResults = JSON.parse(file)
 	} catch (err) {}
-	searchResults[resourcePath] = matches
+	searchResults[resourcePath] = Array.from(new Set([...searchResults[resourcePath] || [], ...matches]))
 	fs.writeFileSync(path, JSON.stringify(searchResults, null, 2), {
 		encoding: 'utf-8',
 		flag: 'w',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "search-loader",
-  "version": "0.2.0",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search-loader",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Search and match file contents for regex patterns.",
   "main": "index.js",
   "scripts": {

--- a/test/otherModule.js
+++ b/test/otherModule.js
@@ -1,1 +1,3 @@
 console.log('Wat')
+console.log('What')
+console.log('Wut')


### PR DESCRIPTION
This PR updates the matchesToFile to append items to a given resourcePath object instead of overriding it.

This will allow two separate instances of the loader to not interfere with each other.

![search_loader_append](https://user-images.githubusercontent.com/15748141/56819207-e1e19900-680e-11e9-927a-d91c1dafd11d.gif)
